### PR TITLE
商品編集機能の実装

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -15,26 +15,6 @@ $(document).on('turbolinks:load', function(){
       return html;
     }
     // 投稿編集時
-    //items/:i/editページへリンクした際のアクション(1回目編集時)
-    if (window.location.href.match(/\/items\/\d+\/edit/)){
-      //登録済み画像のプレビュー表示欄の要素を取得する
-      var prevContent = $('.label-content').prev();
-      labelWidth = (660 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
-      $('.label-content').css('width', labelWidth);
-      //プレビューにidを追加
-      $('.preview-box').each(function(index, box){
-        $(box).attr('id', `preview-box__${index}`);
-      })
-      //削除ボタンにidを追加
-      $('.delete-box').each(function(index, box){
-        $(box).attr('id', `delete_btn_${index}`);
-      })
-      var count = $('.preview-box').length;
-      //プレビューが5あるときは、投稿ボックスを消しておく
-      if (count == 5) {
-        $('.label-content').hide();
-      }
-    }
     //items/:iページへリンクした際のアクション(編集エラー時)
     if (window.location.href.match(/\/items\/\d/)){
       //登録済み画像のプレビュー表示欄の要素を取得する

--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -14,6 +14,48 @@ $(document).on('turbolinks:load', function(){
                   </div>`
       return html;
     }
+    // 投稿編集時
+    //items/:i/editページへリンクした際のアクション(1回目編集時)
+    if (window.location.href.match(/\/items\/\d+\/edit/)){
+      //登録済み画像のプレビュー表示欄の要素を取得する
+      var prevContent = $('.label-content').prev();
+      labelWidth = (660 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
+      $('.label-content').css('width', labelWidth);
+      //プレビューにidを追加
+      $('.preview-box').each(function(index, box){
+        $(box).attr('id', `preview-box__${index}`);
+      })
+      //削除ボタンにidを追加
+      $('.delete-box').each(function(index, box){
+        $(box).attr('id', `delete_btn_${index}`);
+      })
+      var count = $('.preview-box').length;
+      //プレビューが5あるときは、投稿ボックスを消しておく
+      if (count == 5) {
+        $('.label-content').hide();
+      }
+    }
+    //items/:iページへリンクした際のアクション(編集エラー時)
+    if (window.location.href.match(/\/items\/\d/)){
+      //登録済み画像のプレビュー表示欄の要素を取得する
+      var prevContent = $('.label-content').prev();
+      labelWidth = (660 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
+      $('.label-content').css('width', labelWidth);
+      //プレビューにidを追加
+      $('.preview-box').each(function(index, box){
+        $(box).attr('id', `preview-box__${index}`);
+      })
+      //削除ボタンにidを追加
+      $('.delete-box').each(function(index, box){
+        $(box).attr('id', `delete_btn_${index}`);
+      })
+      var count = $('.preview-box').length;
+      //プレビューが5あるときは、投稿ボックスを消しておく
+      if (count == 5) {
+        $('.label-content').hide();
+      }
+    }
+
     // ラベルのwidth操作
     function setLabel() {
       //プレビューボックスのwidthを取得し、maxから引くことでラベルのwidthを決定
@@ -27,7 +69,7 @@ $(document).on('turbolinks:load', function(){
       //hidden-fieldのidの数値のみ取得
       var id = $(this).attr('id').replace(/[^0-9]/g, '');
       //labelボックスのidとforを更新
-      $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
+      $('.label-box').attr({id: `label-box--${id}`,for: `item_item_images_attributes_${id}_url`});
       //選択したfileのオブジェクトを取得
       var file = this.files[0];
       var reader = new FileReader();
@@ -51,12 +93,17 @@ $(document).on('turbolinks:load', function(){
         if (count == 5) { 
           $('.label-content').hide();
         }
+
+        //プレビュー削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す
+        if ($(`#item_item_images_attributes_${id}__destroy`)){
+          $(`#item_item_images_attributes_${id}__destroy`).prop('checked',false);
+        } 
         //ラベルのwidth操作
         setLabel();
         //ラベルのidとforの値を変更
         if(count < 5){
           //プレビューの数でラベルのオプションを更新する
-          $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_url`});
+          $('.label-box').attr({id: `label-box--${count}`,for: `item_item_images_attributes_${count}_url`});
         }
       }
     });
@@ -64,24 +111,36 @@ $(document).on('turbolinks:load', function(){
     $(document).on('click', '.delete-box', function() {
       var count = $('.preview-box').length;
       setLabel(count);
-      //item_images_attributes_${id}_image から${id}に入った数字のみを抽出
       var id = $(this).attr('id').replace(/[^0-9]/g, '');
-      //取得したidに該当するプレビューを削除
       $(`#preview-box__${id}`).remove();
-      console.log("new")
-      //フォームの中身を削除 
-      $(`#item_images_attributes_${id}_url`).val("");
-      //削除時のラベル操作
-      var count = $('.preview-box').length;
-      //5個めが消されたらラベルを表示
-      if (count == 4) {
-        $('.label-content').show();
-      }
-      setLabel(count);
-      if(id < 5){
-        //削除された際に、空っぽになったfile_fieldをもう一度入力可能にする
-        $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
+
+      //新規投稿時
+      //削除用チェックボックスの有無で判定
+      if ($(`#item_item_images_attributes_${id}__destroy`).length == 0) {
+        //フォームの中身を削除 
+        $(`#item_item_images_attributes_${id}_url`).val("");
+        var count = $('.preview-box').length;
+        //5個めが消されたらラベルを表示
+        if (count == 4) {
+          $('.label-content').show();
+        }
+        setLabel(count);
+        if(id < 5){
+          $('.label-box').attr({id: `label-box--${id}`,for: `item_item_images_attributes_${id}_url`});
+        }
+      } else {
+        //投稿編集時
+        $(`#item_item_images_attributes_${id}__destroy`).prop('checked',true);
+        //5個めが消されたらラベルを表示
+        if (count == 4) {
+          $('.label-content').show();
+        }
+        setLabel();
+        if(id < 5){
+          //削除された際に、空っぽになったfile_fieldをもう一度入力可能にする
+          $('.label-box').attr({id: `label-box--${id}`,for: `item_item_images_attributes_${id}_url`});
+        }
       }
     });
   });
-})
+});

--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -179,7 +179,7 @@
   flex-wrap: wrap;
 
   //プレビュー表示欄のCSS
-  .prev-content {
+  .preview-content {
     display: flex;
     .preview-box {
       height: 162px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_items,only: [:index,:show]
+  before_action :set_item,only: [:show, :edit, :update]
   def index
   end
 
@@ -21,15 +22,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to root_path
     else
@@ -48,5 +46,8 @@ class ItemsController < ApplicationController
 
   def set_items
     @items = Item.all
+  end
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,21 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
+
+
+
   private
   def item_params
     params.require(:item).permit( :name, :introduction, :price, :brand, :category_id,

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -11,17 +11,30 @@
       %span{class: "text-file"}最大5枚まで画像登録できます
       .post__drop__box__container
         .preview-content
+          - @item.item_images.each do |image|
+            .preview-box
+              .upper-box
+                = image_tag image.url.url, width: "112", height: "112", alt: "preview"
+              .lower-box
+                .delete-box
+                  %span 削除
         .label-content
-          %label{for: "item_item_images_attributes_0_url", class: "label-box", id: "label-box--0"}
+          = f.label :"item_images_attributes_#{@item.item_images.length}_url", class: "label-box", id: "label-box--#{@item.item_images.length}" do
             %pre.label-box__text-visible
               = icon('fas', 'camera')
         .hidden-content
           = f.fields_for :item_images do |i|
             = i.file_field :url, class: "hidden-field"
-            %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][1][url]", id: "item_item_images_attributes_1_url" }
-            %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][2][url]", id: "item_item_images_attributes_2_url" }
-            %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][3][url]", id: "item_item_images_attributes_3_url" }
-            %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][4][url]", id: "item_item_images_attributes_4_url" }
+            = i.check_box:_destroy, class: "hidden-checkbox"
+
+          - @item.item_images.length.upto(4) do |i|
+            %input{name: "item[item_images_attributes][#{i}][url]", id: "item_item_images_attributes_#{i}_url", class:"hidden-field", type:"file"}
+          
+            -# = i.file_field :url, class: "hidden-field", id: "item_images_attributes_0_url" 
+            -# %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][1][url]", id: "item_images_attributes_1_url" }
+            -# %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][2][url]", id: "item_images_attributes_2_url" }
+            -# %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][3][url]", id: "item_images_attributes_3_url" }
+            -# %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][4][url]", id: "item_images_attributes_4_url" }
 
     .item-content
       %span 商品名
@@ -65,7 +78,7 @@
       %span{class: "text-required"} 必須
       = f.text_field :price, class: "price-area", placeholder:"例）¥300~9,999,999"
 
-    = f.submit '出品する', class: 'submit-btn'
+    = f.submit '更新する', class: 'submit-btn'
 
 .footer
   %ul.contents

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -29,12 +29,6 @@
 
           - @item.item_images.length.upto(4) do |i|
             %input{name: "item[item_images_attributes][#{i}][url]", id: "item_item_images_attributes_#{i}_url", class:"hidden-field", type:"file"}
-          
-            -# = i.file_field :url, class: "hidden-field", id: "item_images_attributes_0_url" 
-            -# %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][1][url]", id: "item_images_attributes_1_url" }
-            -# %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][2][url]", id: "item_images_attributes_2_url" }
-            -# %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][3][url]", id: "item_images_attributes_3_url" }
-            -# %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][4][url]", id: "item_images_attributes_4_url" }
 
     .item-content
       %span 商品名

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -58,7 +58,7 @@
       
       %span 発送方法
       %span{class: "text-required"} 必須
-      = f.collection_select :postage_type_id, PostageType.all, :id, :postagetype
+      = f.collection_select :postage_type_id, PostageType.all, :id, :postagetype,{include_blank: "選択して下さい"}
 
     .item-price
       %span 販売価格

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   resources :signup, only: [:index]
   root to: 'items#index'
-  resources :items, only: [:new, :create, :show]
+  resources :items, only: [:new, :create, :show, :edit, :update]
   devise_for :users
   resources :card, only: [:new, :show]
   resources :mypages, only: [:index] do


### PR DESCRIPTION
#What
出品した商品情報を編集する商品編集機能の実装

#Why
フリマアプリの根幹機能のため。

・編集する出品データ
https://gyazo.com/7c4060c383ccc4e3b584166765eb3cc4
https://gyazo.com/1e53192d130ec23b830b67092fa26fc5

・編集画面
https://gyazo.com/5917c8d40d52286f6774515019fc2c65

・エラーハンドリング
商品出品機能と同様に更新ボタンを押下した時にバリデーションエラー時は
添付画像のように赤字でエラー内容表示する。
https://gyazo.com/e3a5ec1460d7cea42906e0c866728145

・編集後データ
出品データ(Tシャツ)からゲームソフトへデータ編集を実行した。
https://gyazo.com/8335cc38a2f029ee22cda62b86681786
https://gyazo.com/d777f615818e36c0970463de17399690