### PR TITLE
送付先情報、マイページ訂正

### DIFF
--- a/app/assets/stylesheets/modules/_mypages.scss
+++ b/app/assets/stylesheets/modules/_mypages.scss
@@ -116,7 +116,7 @@
       }
 
       &__body2{
-        height:1000px;
+        height:1200px;
         width: 100vh;
         border-color: #fff;
         background-color: white;
@@ -124,12 +124,13 @@
         padding: 30px 200px;
         .change-btn{
           margin-top: 20px;
-          width: 390px;
+          width: 340px;
           color: #fff;
           height: 50px;
           background-color: #3CCACE;
           border-radius: 3px;
           border: 1px none #fff;
+          cursor: pointer;
         }
       }
     }

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -85,21 +85,23 @@
         %table
           %tr
             %th 出品者
-            %td hoge
+            %td 
+              = @item.seller.nickname
           %tr
             %th カテゴリー
             %td 
               = link_to "#",class: "btn"do
-                ベビーキッズ
+                = @item.category.name
               %br
               = link_to "#",class: "btn"do
-                ベビー服
+                = @item.category.name
               %br
               = link_to "#",class: "btn"do
-                アウター
+                = @item.category.name
           %tr
             %th ブランド
             %td 
+              = @item.brand
           %tr
             %th 商品のサイズ
             %td 

--- a/app/views/mypages/_main_mypage.html.haml
+++ b/app/views/mypages/_main_mypage.html.haml
@@ -1,7 +1,8 @@
 .main--mypage
   .main--title
     %h3.main--title__content
-      さんのマイページ
+      = current_user.nickname
+      さんのページ
     .main--item
       .main--item__head
         %h3.main--title

--- a/app/views/mypages/_side_mypage.html.haml
+++ b/app/views/mypages/_side_mypage.html.haml
@@ -32,7 +32,7 @@
       = link_to '#',{class:"side--menu__list--item"} do
         本人情報
     %li.side--menu__list
-      = link_to '#',{class:"side--menu__list--item"} do
+      = link_to new_send_information_path,{class:"side--menu__list--item"} do
         発送元・お届け先住所変更
     %li.side--menu__list<
       = link_to '#',{class:"side--menu__list--item"} do

--- a/app/views/send_informations/_send.html.haml
+++ b/app/views/send_informations/_send.html.haml
@@ -1,7 +1,8 @@
 .main--mypage
   .main--title
     %h3.main--title__content
-      さんのマイページ
+      = current_user.nickname
+      さんのページ
     .main--item
       .main--item__head
         %h3.main--title
@@ -11,34 +12,34 @@
           %p
             お名前(全角)
             %span 必須
-          = f.text_field :send_first_name, class: "login-input-text", placeholder: "例)山田"
-          = f.text_field :send_family_name, class: "login-input-text", placeholder: "例)太郎"
+          = f.text_field :send_first_name, class: "input_field", placeholder: "例)山田"
+          = f.text_field :send_family_name, class: "input_field", placeholder: "例)太郎"
           %p
             お名前(カナ)
             %span 必須
-          = f.text_field :send_first_name_kana, class: "login-input-text", placeholder: "例)ヤマダ"
-          = f.text_field :send_family_name_kana, class: "login-input-text", placeholder: "例)タロウ"
+          = f.text_field :send_first_name_kana, class: "input_field", placeholder: "例)ヤマダ"
+          = f.text_field :send_family_name_kana, class: "input_field", placeholder: "例)タロウ"
           %p
             郵便番号
             %span 必須
-          = f.text_field :post_code, class: "login-input-text", placeholder: "例)000-0000"
+          = f.text_field :post_code, class: "input_field", placeholder: "例)000-0000"
           %p
             都道府県
             %span 必須
-          = f.text_field :prefecture, class: "login-input-text", placeholder: "例)東京都"
+          = f.text_field :prefecture, class: "input_field", placeholder: "例)東京都"
           %p
             市区町村
             %span 必須
-          = f.text_field :city, class: "login-input-text", placeholder: "例)渋谷区"
+          = f.text_field :city, class: "input_field", placeholder: "例)渋谷区"
           %p
             番地
             %span 必須
-          = f.text_field :address, class: "login-input-text", placeholder: "例)神宮前1-1"
+          = f.text_field :address, class: "input_field", placeholder: "例)神宮前1-1"
           %p
             マンション名、部屋番号(任意)
-          = f.text_field :building_name, class: "login-input-text", placeholder: "例)DIVハイツ101号"
+          = f.text_field :building_name, class: "input_field", placeholder: "例)DIVハイツ101号"
           %p
             お届け先の電話番号(任意)
-          = f.text_field :phone_number, class: "login-input-text", placeholder: "例)00-0000-0000"
+          = f.text_field :phone_number, class: "input_field", placeholder: "例)00-0000-0000"
           %p
           = f.submit "変更する", class: "change-btn"


### PR DESCRIPTION
# What
・送付先情報のViewの修正
・送付先情報をマイページからの遷移設定
・詳細ページの出品者、カテゴリ、ブランドの表示

# Why
ルーティングをスムーズにする為
詳細ページの未作成部分を修正